### PR TITLE
Publish to maven central (OSS Repository Hosting) #11

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build and publish
-      run: ./gradlew publish -PreleaseTag=${GITHUB_REF}
+      run: ./gradlew build publishAllPublicationsToGitHubPackagesRepository -PreleaseTag=${GITHUB_REF}
       env:
         USERNAME: ${{ github.actor }}
         PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-**This is a initial version for JUnit5 support for Serenity BDD. Feedback and help are highly appreciated.**
+![master build status](https://github.com/fabianlinz/serenity-junit5/workflows/Build/badge.svg?branch=master)
+[![maven-central](https://img.shields.io/maven-central/v/io.github.fabianlinz/serenity-junit5.svg)](https://search.maven.org/search?q=g:io.github.fabianlinz%20AND%20a:serenity-junit5)
+
+**This is a early version of JUnit5 support for Serenity BDD. Feedback and help are highly appreciated.**
 
 # Writing and running Serenity BDD tests with JUnit5 (Jupiter test engine)
 The [Serenity BDD](https://github.com/serenity-bdd/serenity-core) features described for JUnit4 (http://thucydides.info/docs/serenity-staging/#_serenity_with_junit)
@@ -10,7 +13,7 @@ different of cause (see also https://junit.org/junit5/docs/current/user-guide/#m
 To run a JUnit5 test with Serenity BDD, simply add the annotation `@net.serenitybdd.junit5.SerenityTest` (instead of `@org.junit.runner.RunWith(net.serenitybdd.junit.runners.SerenityRunner.class`) for JUnit4)
 
 Basic example (analog to http://thucydides.info/docs/serenity-staging/#_basic_junit_integration):
-```
+```java
 @SerenityTest                                                       
 public class WhenCalculatingFrequentFlyerPoints {
 
@@ -30,6 +33,17 @@ public class WhenCalculatingFrequentFlyerPoints {
 
     }
 }
+```
+
+
+To get started just include a dependency to [`io.github.fabianlinz:serenity-junit5`](https://search.maven.org/search?q=g:io.github.fabianlinz%20AND%20a:serenity-junit5).
+
+Adding a direct dependency to `serenity-core` allows to easily use newer versions of Serenity. The transitive dependency to JUnit4 should be excluded though:
+```
+    testImplementation ('io.github.fabianlinz:serenity-junit5:VERSION')
+    testImplementation ('net.serenity-bdd:serenity-core:VERSION') { // optional: in case a newer version should be used
+        exclude group: 'junit', module: 'junit'
+    }
 ```
 
 # Why JUnit5 support for Serenity BDD?

--- a/serenity-junit5/build.gradle
+++ b/serenity-junit5/build.gradle
@@ -1,5 +1,5 @@
 group = 'io.github.fabianlinz'
-version =  project.hasProperty('releaseTag') ? project.property('releaseTag').replace('refs/tags/', '') : '0.0.1-SNAPSHOT'
+version =  project.hasProperty('releaseTag') ? project.property('releaseTag').replace('refs/tags/', '') : (project.hasProperty('branch') ? branchVersion() : '0.0.1-SNAPSHOT')
 
 apply plugin: 'java-library'
 apply plugin: 'eclipse'
@@ -55,10 +55,10 @@ test {
 
 test.finalizedBy(aggregate)
 
-task sourceJar(type: Jar) {
-    from sourceSets.main.allJava
+java {
+    withJavadocJar()
+    withSourcesJar()
 }
-
 publishing {
     repositories {
         maven {
@@ -69,27 +69,57 @@ publishing {
                 password = System.getenv("PASSWORD")
             }
         }
+
+        maven {
+            name = "OSSRH"
+            def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+            def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
+            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+            credentials {
+                username = System.getenv("OSSRH_USER")
+                password = System.getenv("OSSRH_PASSWORD")
+            }
+        }
     }
 
     publications {
-        gpr(MavenPublication) {
+        maven(MavenPublication) {
             from components.java
-            artifact sourceJar {
-                classifier "sources"
-            }
 
             pom {
-                name.set("Serenity JUnit5")
-                url.set("https://github.com/fabianlinz/serenity-junit5")
+                name = "Serenity JUnit5"
+                description = "Writing and running Serenity BDD tests with JUnit5 (Jupiter test engine)"
+                url = "https://github.com/fabianlinz/serenity-junit5"
                 licenses {
                     license {
-                        name.set("Apache-2.0 License")
-                        url.set("https://github.com/fabianlinz/serenity-junit5/blob/master/LICENSE")
+                        name = "The Apache License, Version 2.0"
+                        url = "https://github.com/fabianlinz/serenity-junit5/blob/master/LICENSE"
                     }
+                }
+                developers {
+                    developer {
+                        name = 'Fabian Linz'
+                        organizationUrl = "https://github.com/fabianlinz"
+                    }
+                }
+                scm {
+                    connection = 'scm:git:git://github.com:fabianlinz/serenity-junit5.git'
+                    developerConnection = 'scm:git://github.com:fabianlinz/serenity-junit5.git'
+                    url = 'https://github.com/fabianlinz/serenity-junit5'
                 }
             }
         }
     }
 }
 
+javadoc {
+    if(JavaVersion.current().isJava9Compatible()) {
+        options.addBooleanOption('html5', true)
+    }
+}
+
 publish.dependsOn(build)
+
+private branchVersion() {
+    project.property('branch').replace('refs/heads/', '').replace('/', '-') + "-SNAPSHOT"
+}


### PR DESCRIPTION
* Actual publishing to maven central is done outside of this project based on the build artifacts published for a release to GitHub Packages (so they are not build again). This is done to ensure secrecy of the password to OSSRH and the required GPG/PGP signatures. (see also https://central.sonatype.org/pages/requirements.html)
* OSSRH configuration included in gradle to simplify SNAPSHOT releases in case they are needed. Would be available under `https://oss.sonatype.org/content/groups/public/`