### PR TITLE
Add support for Serenity @Manual annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ For teams using JUnit to declare the Serenity scenarios, the difference is somet
     * different annotations are used for the lifecycle hooks
     * different extension mechanism: JUnit4 Rule vs. JUnit5 Extension
 
+## Notes on supported features
+* Junit5 `@Disabled` annotation can be used on *test* and *step* methods
+   * The following table outlines the difference of using JUnit5 `@Disabled` and Serenity `@Pending` on a step method
+
+        | Consequence of annotated step method for...     | JUnit5 `@Disabled` (same as `@Ignore` in JUnit4)         | Serenity `@Pending`  | 
+        | ------------------------------------------------|--------------------------------------------------------------| --------| 
+        | test outcome                                    | `ignored` | `pending` |
+        | annotated step method                           | skipped (= not executed) | skipped (= not executed) |
+        | annotated step method in report                 | `ignored`  | `pending` |
+        | step methods after the annotated step           | executed   | skipped (= not executed)|
+        | step methods after the annotated step in report | depending on execution e.g. `success`   | `ignored` |
+
 # Known limitations/currently not supported features:
 
 ## Serenity BDD features
@@ -63,8 +75,6 @@ For teams using JUnit to declare the Serenity scenarios, the difference is somet
     * Tags are shown in the report
     * Filtering of tests not possible => works with JUnit5 `@Tag` though
     * Overlap with JUnit5 `@Tag` support
-* `@Manual`
-    * see also `net.serenitybdd.junit.runners.SerenityRunner#markAsManual`)
 * `@Title`
     * http://thucydides.info/docs/serenity-staging/#_human_readable_method_titles
     * The title is not considered for report nor as test name from JUnit perspective
@@ -83,7 +93,7 @@ For teams using JUnit to declare the Serenity scenarios, the difference is somet
 ## JUnit5 features
 * `@Nested`
     * Injection not working (Steps, Page and WebDriver)
-    * Story name should propably be a combination of the parent name and the nested test class name
+    * Story name should probably be a combination of the parent name and the nested test class name
     * see also https://junit.org/junit5/docs/current/user-guide/#writing-tests-nested
 * `@Tag`
     * NOT considered for the report
@@ -113,19 +123,6 @@ For teams using JUnit to declare the Serenity scenarios, the difference is somet
 * @RepeatedTest
 * @TestFactory
 * @TestTemplate
-
-## Notes on supported features
-* Junit5 `@Disabled` annotation can be used on *test* and *step* methods
-   * The following table outlines the difference of using JUnit5 `@Disabled` and Serenity `@Pending` on a step method
-
-        | Consequence of annotated step method for...     | JUnit5 `@Disabled` (same as `@Ignore` in JUnit4)         | Serenity `@Pending`  | 
-        | ------------------------------------------------|--------------------------------------------------------------| --------| 
-        | test outcome                                    | `ignored` | `pending` |
-        | annotated step method                           | skipped (= not executed) | skipped (= not executed) |
-        | annotated step method in report                 | `ignored`  | `pending` |
-        | step methods after the annotated step           | executed   | skipped (= not executed)|
-        | step methods after the annotated step in report | depending on execution e.g. `success`   | `ignored` |
-
 
 ## General notes:
 * Should there be an alternative for identifying WebTests?

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,4 @@ assertJVersion = 3.13.2
 slf4jVersion = 1.7.28
 testContainerVersion = 1.14.3
 junitVersion = 4.12
+lombokVersion = 1.18.16

--- a/serenity-junit4-starter/src/test/java/starter/ManualTest.java
+++ b/serenity-junit4-starter/src/test/java/starter/ManualTest.java
@@ -1,0 +1,91 @@
+package starter;
+
+import net.serenitybdd.junit.runners.SerenityRunner;
+import net.thucydides.core.annotations.Manual;
+import net.thucydides.core.annotations.Pending;
+import net.thucydides.core.model.TestResult;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(SerenityRunner.class)
+public class ManualTest {
+
+    @Test
+    @Pending
+    public void pending() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Test
+    @Ignore
+    public void ignored() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Test
+    @Manual
+    public void manualDefault() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Test
+    @Manual(result = TestResult.COMPROMISED)
+    public void manualCompromised() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Test
+    @Manual(result = TestResult.ERROR)
+    public void manualError() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Test
+    @Manual(result = TestResult.ERROR, reason = "A reason for the error")
+    public void manualErrorWithReason() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Test
+    @Manual(result = TestResult.FAILURE)
+    public void manualFailure() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Test
+    @Manual(result = TestResult.IGNORED)
+    public void manualIgnored() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Test
+    @Manual(result = TestResult.PENDING)
+    public void manualPending() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Test
+    @Manual(result = TestResult.SKIPPED)
+    public void manualSkipped() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Test
+    @Manual(result = TestResult.SUCCESS)
+    public void manualSuccess() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Test
+    @Manual(result = TestResult.UNDEFINED)
+    public void manualUndefined() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Test
+    @Manual(result = TestResult.UNSUCCESSFUL)
+    public void manualUnsuccessful() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/serenity-junit5-starter/src/test/java/starter/DisabledVsPendingTest.java
+++ b/serenity-junit5-starter/src/test/java/starter/DisabledVsPendingTest.java
@@ -1,4 +1,4 @@
-package starter.math;
+package starter;
 
 import net.serenitybdd.junit5.SerenityTest;
 import net.thucydides.core.annotations.Pending;

--- a/serenity-junit5-starter/src/test/java/starter/ManualTest.java
+++ b/serenity-junit5-starter/src/test/java/starter/ManualTest.java
@@ -1,0 +1,90 @@
+package starter;
+
+import net.serenitybdd.junit5.SerenityTest;
+import net.thucydides.core.annotations.Manual;
+import net.thucydides.core.annotations.Pending;
+import net.thucydides.core.model.TestResult;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+@SerenityTest
+public class ManualTest {
+
+    @Test
+    @Pending
+    void pending() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Test
+    @Disabled
+    void disabled() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Test
+    @Manual
+    void manualDefault() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Test
+    @Manual(result = TestResult.SUCCESS)
+    void manualSuccess() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Test
+    @Manual(result = TestResult.COMPROMISED)
+    void manualCompromised() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Test
+    @Manual(result = TestResult.ERROR)
+    void manualError() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Test
+    @Manual(result = TestResult.ERROR, reason = "A reason for the error")
+    void manualErrorWithReason() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Test
+    @Manual(result = TestResult.FAILURE)
+    void manualFailure() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Test
+    @Manual(result = TestResult.IGNORED)
+    void manualIgnored() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Test
+    @Manual(result = TestResult.PENDING)
+    void manualPending() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Test
+    @Manual(result = TestResult.SKIPPED)
+    void manualSkipped() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Test
+    @Manual(result = TestResult.UNDEFINED)
+    void manualUndefined() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Test
+    @Manual(result = TestResult.UNSUCCESSFUL)
+    void manualUnsuccessful() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/serenity-junit5-starter/src/test/java/starter/PureJunit5Test.java
+++ b/serenity-junit5-starter/src/test/java/starter/PureJunit5Test.java
@@ -1,6 +1,8 @@
-package starter.math;
+package starter;
 
 import net.serenitybdd.junit5.SerenityTest;
+import net.thucydides.core.annotations.Manual;
+import net.thucydides.core.model.TestResult;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;

--- a/serenity-junit5/build.gradle
+++ b/serenity-junit5/build.gradle
@@ -16,8 +16,11 @@ repositories {
 }
 
 dependencies {
+    annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+    compileOnly "org.projectlombok:lombok:${lombokVersion}"
+
     api ("net.serenity-bdd:serenity-core:${serenityCoreVersion}") {
-        exclude group: 'junit', module: 'junit' //by both name and group
+        exclude group: 'junit', module: 'junit'
     }
     api "org.junit.jupiter:junit-jupiter-api:${junit5Version}"
 
@@ -30,10 +33,10 @@ dependencies {
     // > https://www.testcontainers.org/test_framework_integration/junit_5
     // > https://github.com/testcontainers/testcontainers-java/issues/87
     testImplementation ("org.testcontainers:selenium:${testContainerVersion}") {
-        exclude group: 'junit', module: 'junit' //by both name and group
+        exclude group: 'junit', module: 'junit'
     }
     testImplementation ("org.testcontainers:junit-jupiter:${testContainerVersion}") {
-        exclude group: 'junit', module: 'junit' //by both name and group
+        exclude group: 'junit', module: 'junit'
     }
     // Because Testcontainers requires JUnit4 rule support to be on the classpath the JUnit5 migration-support is used here
     // (which bring Junit4 back to the classpath)

--- a/serenity-junit5/src/main/java/net/serenitybdd/junit5/SerenityTestWithoutReporting.java
+++ b/serenity-junit5/src/main/java/net/serenitybdd/junit5/SerenityTestWithoutReporting.java
@@ -2,9 +2,9 @@ package net.serenitybdd.junit5;
 
 import net.serenitybdd.junit5.extension.SerenityExtension;
 import net.serenitybdd.junit5.extension.SerenityJUnitLifecycleAdapterExtension;
+import net.serenitybdd.junit5.extension.SerenityManualExtension;
 import net.serenitybdd.junit5.extension.SerenityStepExtension;
 import net.serenitybdd.junit5.extension.page.SerenityPageExtension;
-
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.lang.annotation.Documented;
@@ -24,7 +24,11 @@ import java.lang.annotation.Target;
 @ExtendWith({
         SerenityExtension.class,
         SerenityJUnitLifecycleAdapterExtension.class,
+        SerenityManualExtension.class,
         SerenityPageExtension.class,
         SerenityStepExtension.class})
 public @interface SerenityTestWithoutReporting {
 }
+
+
+

--- a/serenity-junit5/src/main/java/net/serenitybdd/junit5/extension/SerenityManualExtension.java
+++ b/serenity-junit5/src/main/java/net/serenitybdd/junit5/extension/SerenityManualExtension.java
@@ -1,0 +1,79 @@
+package net.serenitybdd.junit5.extension;
+
+import net.thucydides.core.annotations.Manual;
+import net.thucydides.core.annotations.ManualTestMarkedAsError;
+import net.thucydides.core.annotations.ManualTestMarkedAsFailure;
+import net.thucydides.core.steps.StepEventBus;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.InvocationInterceptor;
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
+
+import java.lang.reflect.Method;
+
+import static net.thucydides.core.model.TestResult.FAILURE;
+import static net.thucydides.core.steps.StepEventBus.getEventBus;
+
+// net.serenitybdd.junit.runners.SerenityRunner.markAsManual
+// start and end events for tests will be fired by SerenityJUnitLifecycleAdapterExtension
+public class SerenityManualExtension implements InvocationInterceptor {
+
+    @Override
+    public void interceptTestMethod(final Invocation<Void> invocation,
+                                    final ReflectiveInvocationContext<Method> invocationContext,
+                                    final ExtensionContext extensionContext) throws Throwable {
+        final Method testMethod = extensionContext.getRequiredTestMethod();
+
+        if (testMethod.isAnnotationPresent(Manual.class)) {
+            invocation.skip();
+            markAsManual(testMethod.getAnnotation(Manual.class), getEventBus());
+        } else {
+            invocation.proceed();
+        }
+    }
+
+    private void markAsManual(final Manual manualAnnotation, final StepEventBus eventBus) throws Throwable {
+        eventBus.testIsManual();
+
+        eventBus.getBaseStepListener().latestTestOutcome().ifPresent(
+                outcome -> {
+                    outcome.setResult(manualAnnotation.result());
+                    if (manualAnnotation.result() == FAILURE) {
+                        outcome.setTestFailureMessage(manualReasonDeclaredIn(manualAnnotation));
+                    }
+                }
+        );
+
+        switch(manualAnnotation.result()) {
+            case SUCCESS:
+                return;
+            case FAILURE:
+                final Throwable failure = new ManualTestMarkedAsFailure(manualReasonDeclaredIn(manualAnnotation));
+                eventBus.testFailed(failure);
+                throw failure;
+            case ERROR:
+            case COMPROMISED:
+            case UNSUCCESSFUL:
+                final Throwable error = new ManualTestMarkedAsError(manualReasonDeclaredIn(manualAnnotation));
+                eventBus.testFailed(error);
+                throw error;
+            case IGNORED:
+                eventBus.testIgnored();
+                throwMarkerExceptionForAnAbortedExecutionInJunit5(manualAnnotation);
+            case SKIPPED:
+                eventBus.testSkipped();
+                throwMarkerExceptionForAnAbortedExecutionInJunit5(manualAnnotation);
+            default:
+                eventBus.testPending();
+                throwMarkerExceptionForAnAbortedExecutionInJunit5(manualAnnotation);
+        }
+    }
+
+    private void throwMarkerExceptionForAnAbortedExecutionInJunit5(final Manual manualAnnotation) {
+        throw new SerenityJUnitLifecycleAdapterExtension.ManualTestAbortedException(manualAnnotation.result());
+    }
+
+    private String manualReasonDeclaredIn(final Manual manualAnnotation) {
+        final String reason = manualAnnotation.reason();
+        return reason == null ? "Manual test failure" : "Manual test failure: " + reason;
+    }
+}

--- a/serenity-junit5/src/test/java/net/serenitybdd/junit5/extension/WhenRunningManualTests.java
+++ b/serenity-junit5/src/test/java/net/serenitybdd/junit5/extension/WhenRunningManualTests.java
@@ -1,0 +1,224 @@
+package net.serenitybdd.junit5.extension;
+
+import net.serenitybdd.junit5.extension.testsupport.SerenityExtensionInnerTest;
+import net.serenitybdd.junit5.extension.testsupport.SerenityExtensionTest;
+import net.thucydides.core.annotations.Manual;
+import net.thucydides.core.annotations.Pending;
+import net.thucydides.core.annotations.Steps;
+import org.junit.jupiter.api.Test;
+
+import static net.thucydides.core.model.TestResult.COMPROMISED;
+import static net.thucydides.core.model.TestResult.ERROR;
+import static net.thucydides.core.model.TestResult.FAILURE;
+import static net.thucydides.core.model.TestResult.IGNORED;
+import static net.thucydides.core.model.TestResult.PENDING;
+import static net.thucydides.core.model.TestResult.SKIPPED;
+import static net.thucydides.core.model.TestResult.SUCCESS;
+import static net.thucydides.core.model.TestResult.UNDEFINED;
+import static net.thucydides.core.model.TestResult.UNSUCCESSFUL;
+
+@SerenityExtensionTest
+class WhenRunningManualTests {
+
+    @Steps
+    private JUnit5Steps junit5;
+
+    @Test
+    void the_outcome_should_be_defined_by_manual_annotation_and_ignore_pending_annotation() {
+        // when
+        junit5.executesTestClass(ManualTakesPrecedenceOverPending.class);
+
+        // then
+        junit5.shouldHaveExactlyOneTestOutcomeWithResult(COMPROMISED);
+    }
+
+    @SerenityExtensionInnerTest
+    static class ManualTakesPrecedenceOverPending {
+        @Test
+        @Manual(result = COMPROMISED)
+        @Pending
+        void manualDefault() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @Test
+    void the_outcome_should_default_to_pending() {
+        // when
+        junit5.executesTestClass(ManualDefault.class);
+
+        // then
+        junit5.shouldHaveExactlyOneTestOutcomeWithResult(PENDING);
+    }
+
+    @SerenityExtensionInnerTest
+    static class ManualDefault {
+        @Test
+        @Manual
+        void manualDefault() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @Test
+    void the_outcome_should_be_success() {
+        // when
+        junit5.executesTestClass(ManualSuccess.class);
+
+        // then
+        junit5.shouldHaveExactlyOneTestOutcomeWithResult(SUCCESS);
+    }
+
+    @SerenityExtensionInnerTest
+    static class ManualSuccess {
+        @Test
+        @Manual(result = SUCCESS)
+        void manualSuccess() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @Test
+    void the_outcome_should_be_failure() {
+        // when
+        junit5.executesTestClass(ManualFailure.class);
+
+        // then
+        junit5.shouldHaveExactlyOneTestOutcomeWithResult(FAILURE);
+    }
+
+    @SerenityExtensionInnerTest
+    static class ManualFailure {
+        @Test
+        @Manual(result = FAILURE)
+        void manualFailure() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @Test
+    void the_outcome_should_be_ignored() {
+        // when
+        junit5.executesTestClass(ManualIgnored.class);
+
+        // then
+        junit5.shouldHaveExactlyOneTestOutcomeWithResult(IGNORED);
+    }
+
+    @SerenityExtensionInnerTest
+    static class ManualIgnored {
+        @Test
+        @Manual(result = IGNORED)
+        void manualIgnored() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @Test
+    void the_outcome_should_be_pending() {
+        // when
+        junit5.executesTestClass(ManualPending.class);
+
+        // then
+        junit5.shouldHaveExactlyOneTestOutcomeWithResult(PENDING);
+    }
+
+    @SerenityExtensionInnerTest
+    static class ManualPending {
+        @Test
+        @Manual(result = PENDING)
+        void manualPending() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @Test
+    void the_outcome_should_be_skipped() {
+        // when
+        junit5.executesTestClass(ManualSkipped.class);
+
+        // then
+        junit5.shouldHaveExactlyOneTestOutcomeWithResult(SKIPPED);
+    }
+
+    @SerenityExtensionInnerTest
+    static class ManualSkipped {
+        @Test
+        @Manual(result = SKIPPED)
+        void manualSkipped() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @Test
+    void the_outcome_should_be_pending_for_undefined() {
+        // when
+        junit5.executesTestClass(ManualUndefined.class);
+
+        // then
+        junit5.shouldHaveExactlyOneTestOutcomeWithResult(PENDING);
+    }
+
+    @SerenityExtensionInnerTest
+    static class ManualUndefined {
+        @Test
+        @Manual(result = UNDEFINED)
+        void manualUndefined() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @Test
+    void the_outcome_should_be_error() {
+        // when
+        junit5.executesTestClass(ManualError.class);
+
+        // then
+        junit5.shouldHaveExactlyOneTestOutcomeWithResult(ERROR);
+    }
+
+    @SerenityExtensionInnerTest
+    static class ManualError {
+        @Test
+        @Manual(result = ERROR)
+        void manualError() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @Test
+    void the_outcome_should_be_error_for_unsuccessful() {
+        // when
+        junit5.executesTestClass(ManualUnsuccessful.class);
+
+        // then
+        junit5.shouldHaveExactlyOneTestOutcomeWithResult(ERROR);
+    }
+
+    @SerenityExtensionInnerTest
+    static class ManualUnsuccessful {
+        @Test
+        @Manual(result = UNSUCCESSFUL)
+        void manualUnsuccessful() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @Test
+    void the_outcome_should_be_error_for_compromised() {
+        // when
+        junit5.executesTestClass(ManualCompromised.class);
+
+        // then
+        junit5.shouldHaveExactlyOneTestOutcomeWithResult(COMPROMISED);
+    }
+
+    @SerenityExtensionInnerTest
+    static class ManualCompromised {
+        @Test
+        @Manual(result = COMPROMISED)
+        void manualCompromised() {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/serenity-junit5/src/test/java/net/serenitybdd/junit5/extension/WhenRunningManualWithReasonTests.java
+++ b/serenity-junit5/src/test/java/net/serenitybdd/junit5/extension/WhenRunningManualWithReasonTests.java
@@ -1,0 +1,213 @@
+package net.serenitybdd.junit5.extension;
+
+import net.serenitybdd.junit5.extension.testsupport.SerenityExtensionInnerTest;
+import net.serenitybdd.junit5.extension.testsupport.SerenityExtensionTest;
+import net.thucydides.core.annotations.Manual;
+import net.thucydides.core.annotations.Steps;
+import org.junit.jupiter.api.Test;
+
+import static net.thucydides.core.model.TestResult.COMPROMISED;
+import static net.thucydides.core.model.TestResult.ERROR;
+import static net.thucydides.core.model.TestResult.FAILURE;
+import static net.thucydides.core.model.TestResult.IGNORED;
+import static net.thucydides.core.model.TestResult.PENDING;
+import static net.thucydides.core.model.TestResult.SKIPPED;
+import static net.thucydides.core.model.TestResult.SUCCESS;
+import static net.thucydides.core.model.TestResult.UNDEFINED;
+import static net.thucydides.core.model.TestResult.UNSUCCESSFUL;
+
+@SerenityExtensionTest
+/**
+ * Reason is actually only supported (in Junit4/SerenityRunner) for 
+ * * FAILURE
+ * * ERROR
+ * * COMPROMISED
+ * * UNSUCCESSFUL
+ */
+class WhenRunningManualWithReasonTests {
+
+    public static final String REASON_IS_IGNORED = null;
+    public static final String HAS_REASON = "Manual test failure: Test reason";
+    @Steps
+    private JUnit5Steps junit5;
+
+    @Test
+    void the_outcome_should_have_reason_error() {
+        // when
+        junit5.executesTestClass(ManualError.class);
+
+        // then
+        junit5.shouldHaveExactlyOneTestResultXMatchingY(ERROR, HAS_REASON);
+    }
+
+    @SerenityExtensionInnerTest
+    static class ManualError {
+        @Test
+        @Manual(reason = "Test reason", result = ERROR)
+        void manualError() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @Test
+    void the_outcome_should_have_reason_error_for_unsuccessful() {
+        // when
+        junit5.executesTestClass(ManualUnsuccessful.class);
+
+        // then
+        junit5.shouldHaveExactlyOneTestResultXMatchingY(ERROR, HAS_REASON);
+    }
+
+    @SerenityExtensionInnerTest
+    static class ManualUnsuccessful {
+        @Test
+        @Manual(reason = "Test reason", result = UNSUCCESSFUL)
+        void manualUnsuccessful() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @Test
+    void the_outcome_should_have_reason_error_for_compromised() {
+        // when
+        junit5.executesTestClass(ManualCompromised.class);
+
+        // then
+        junit5.shouldHaveExactlyOneTestResultXMatchingY(COMPROMISED, HAS_REASON);
+    }
+
+    @Test
+    void the_outcome_should_have_reason_failure() {
+        // when
+        junit5.executesTestClass(ManualFailure.class);
+
+        // then
+        junit5.shouldHaveExactlyOneTestResultXMatchingY(FAILURE, HAS_REASON);
+    }
+
+    @SerenityExtensionInnerTest
+    static class ManualFailure {
+        @Test
+        @Manual(reason = "Test reason", result = FAILURE)
+        void manualFailure() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @SerenityExtensionInnerTest
+    static class ManualCompromised {
+        @Test
+        @Manual(reason = "Test reason", result = COMPROMISED)
+        void manualCompromised() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @Test
+    void the_outcome_should_ignore_reason_for_default_of_pending() {
+        // when
+        junit5.executesTestClass(ManualDefault.class);
+
+        // then
+        junit5.shouldHaveExactlyOneTestResultXMatchingY(PENDING, REASON_IS_IGNORED);
+    }
+
+    @SerenityExtensionInnerTest
+    static class ManualDefault {
+        @Test
+        @Manual(reason = "Test reason")
+        void manualDefault() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @Test
+    void the_outcome_should_ignore_reason_for_success() {
+        // when
+        junit5.executesTestClass(ManualSuccess.class);
+
+        // then
+        junit5.shouldHaveExactlyOneTestResultXMatchingY(SUCCESS, REASON_IS_IGNORED);
+    }
+
+    @SerenityExtensionInnerTest
+    static class ManualSuccess {
+        @Test
+        @Manual(reason = "Test reason", result = SUCCESS)
+        void manualSuccess() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @Test
+    void the_outcome_should_ignore_reason_for_ignored() {
+        // when
+        junit5.executesTestClass(ManualIgnored.class);
+
+        // then
+        junit5.shouldHaveExactlyOneTestResultXMatchingY(IGNORED, REASON_IS_IGNORED);
+    }
+
+    @SerenityExtensionInnerTest
+    static class ManualIgnored {
+        @Test
+        @Manual(reason = "Test reason", result = IGNORED)
+        void manualIgnored() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @Test
+    void the_outcome_should_ignore_reason_for__pending() {
+        // when
+        junit5.executesTestClass(ManualPending.class);
+
+        // then
+        junit5.shouldHaveExactlyOneTestResultXMatchingY(PENDING, REASON_IS_IGNORED);
+    }
+
+    @SerenityExtensionInnerTest
+    static class ManualPending {
+        @Test
+        @Manual(reason = "Test reason", result = PENDING)
+        void manualPending() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @Test
+    void the_outcome_should_ignore_reason_for_skipped() {
+        // when
+        junit5.executesTestClass(ManualSkipped.class);
+
+        // then
+        junit5.shouldHaveExactlyOneTestResultXMatchingY(SKIPPED, REASON_IS_IGNORED);
+    }
+
+    @SerenityExtensionInnerTest
+    static class ManualSkipped {
+        @Test
+        @Manual(reason = "Test reason", result = SKIPPED)
+        void manualSkipped() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @Test
+    void the_outcome_should_ignore_reason_for_pending_for_undefined() {
+        // when
+        junit5.executesTestClass(ManualUndefined.class);
+
+        // then
+        junit5.shouldHaveExactlyOneTestResultXMatchingY(PENDING, REASON_IS_IGNORED);
+    }
+
+    @SerenityExtensionInnerTest
+    static class ManualUndefined {
+        @Test
+        @Manual(reason = "Test reason", result = UNDEFINED)
+        void manualUndefined() {
+            throw new UnsupportedOperationException();
+        }
+    }
+}


### PR DESCRIPTION
Examples for `ManualTest` in Junit4 and Junit5 starter.

<img width="1749" alt="report_junit4" src="https://user-images.githubusercontent.com/8121542/99887888-778e1600-2c48-11eb-90cc-f8896d9e56e3.png">
<img width="1749" alt="report_junit5" src="https://user-images.githubusercontent.com/8121542/99887889-78bf4300-2c48-11eb-995a-005290a7c883.png">

**Junit5**
<img width="975" alt="ide_junit5" src="https://user-images.githubusercontent.com/8121542/99887890-7957d980-2c48-11eb-8d9a-cacc7b787397.png">

**JUnit4**
<img width="975" alt="ide_junit4" src="https://user-images.githubusercontent.com/8121542/99887891-7957d980-2c48-11eb-8bba-e28e8f1f1fd0.png">
